### PR TITLE
Ojs33

### DIFF
--- a/InlineHtmlGalleyPlugin.inc.php
+++ b/InlineHtmlGalleyPlugin.inc.php
@@ -54,6 +54,11 @@ class InlineHtmlGalleyPlugin extends HtmlArticleGalleyPlugin {
 			);
 			PluginRegistry::register(
 				'blocks',
+				new InlineHtmlGalleyDetailsSidebarBlockPlugin($this->getName(), $this->getPluginPath()),
+				$this->getPluginPath()
+			);
+			PluginRegistry::register(
+				'blocks',
 				new InlineHtmlGalleyPublishedDateSidebarBlockPlugin($this->getName(), $this->getPluginPath()),
 				$this->getPluginPath()
 			);

--- a/InlineHtmlGalleySidebarBlockPlugin.inc.php
+++ b/InlineHtmlGalleySidebarBlockPlugin.inc.php
@@ -86,6 +86,12 @@ class InlineHtmlGalleyCoverImageSidebarBlockPlugin extends InlineHtmlGalleySideb
     }
 }
 
+class InlineHtmlGalleyDetailsSidebarBlockPlugin extends InlineHtmlGalleySidebarBlockPlugin {
+    function blockName() {
+        return "details";
+    }
+}
+
 class InlineHtmlGalleyPublishedDateSidebarBlockPlugin extends InlineHtmlGalleySidebarBlockPlugin {
     function blockName() {
         return "publishedDate";

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -90,4 +90,4 @@ msgid "plugins.generic.inlineHtmlGalley.settings.xpath.description"
 msgstr "This XPath expression will be used to select which elements in the HTML galley will be displayed on the article landing page. If this is left blank, the default behavior is to display the contents of the body tag."
 
 msgid "plugins.generic.inlineHtmlGalley.backToTop"
-msgstr "Back to Topp "
+msgstr "Back to Top"

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -1,0 +1,93 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2021-10-06T11:07:43-04:00\n"
+"PO-Revision-Date: 2021-10-06T11:07:43-04:00\n"
+"Language: \n"
+
+msgid "plugins.generic.inlineHtmlGalley.displayName"
+msgstr "Inline HTML Galley for Bootstrap"
+
+msgid "plugins.generic.inlineHtmlGalley.description"
+msgstr "This plugin provides inline rendering support for HTML Galleys."
+
+msgid "plugins.generic.inlineHtmlGalley.block.download.displayName"
+msgstr "HTML Galley Download Link"
+
+msgid "plugins.generic.inlineHtmlGalley.block.download.description"
+msgstr "This block provides a link to download the HTML Galley directly."
+
+msgid "plugins.generic.inlineHtmlGalley.block.keywords.displayName"
+msgstr "Inline HTML Galley Sidebar: Keywords"
+
+msgid "plugins.generic.inlineHtmlGalley.block.keywords.description"
+msgstr "This block displays the article's keywords."
+
+msgid "plugins.generic.inlineHtmlGalley.block.authors.displayName"
+msgstr "Inline HTML Galley Sidebar: Authors"
+
+msgid "plugins.generic.inlineHtmlGalley.block.authors.description"
+msgstr "This block displays the article's authors."
+
+msgid "plugins.generic.inlineHtmlGalley.block.doi.displayName"
+msgstr "Inline HTML Galley Sidebar: DOI"
+
+msgid "plugins.generic.inlineHtmlGalley.block.doi.description"
+msgstr "This block provides a DOI link."
+
+msgid "plugins.generic.inlineHtmlGalley.block.coverImage.displayName"
+msgstr "Inline HTML Galley Sidebar: Article/Issue Cover Image"
+
+msgid "plugins.generic.inlineHtmlGalley.block.coverImage.description"
+msgstr "This block shows the article/issue cover image."
+
+msgid "plugins.generic.inlineHtmlGalley.block.details.displayName"
+msgstr "Inline HTML Galley Sidebar: Article Details"
+
+msgid "plugins.generic.inlineHtmlGalley.block.article.description"
+msgstr "This block provides a location for content formerly shown in the Article Details section in non-inlineHtmlGalley sites."
+
+msgid "plugins.generic.inlineHtmlGalley.block.publishedDate.displayName"
+msgstr "Inline HTML Galley Sidebar: Published Date"
+
+msgid "plugins.generic.inlineHtmlGalley.block.publishedDate.description"
+msgstr "This block shows the publishing date of the article."
+
+msgid "plugins.generic.inlineHtmlGalley.block.howToCite.displayName"
+msgstr "Inline HTML Galley Sidebar: How To Cite"
+
+msgid "plugins.generic.inlineHtmlGalley.block.howToCite.description"
+msgstr "This block shows citation information for the article."
+
+msgid "plugins.generic.inlineHtmlGalley.block.license.displayName"
+msgstr "Inline HTML Galley Sidebar: License"
+
+msgid "plugins.generic.inlineHtmlGalley.block.license.description"
+msgstr "This block shows license information for the article."
+
+msgid "plugins.generic.inlineHtmlGalley.block.references.displayName"
+msgstr "Inline HTML Galley Sidebar: References"
+
+msgid "plugins.generic.inlineHtmlGalley.block.references.description"
+msgstr "This block shows article references."
+
+msgid "plugins.generic.inlineHtmlGalley.block.galleys.displayName"
+msgstr "Inline HTML Galley Sidebar: Galleys"
+
+msgid "plugins.generic.inlineHtmlGalley.block.galleys.description"
+msgstr "This block shows download links for any article galleys."
+
+msgid "plugins.generic.inlineHtmlGalley.settings.xpath"
+msgstr "XPath"
+
+msgid "plugins.generic.inlineHtmlGalley.settings.xpath.description"
+msgstr "This XPath expression will be used to select which elements in the HTML galley will be displayed on the article landing page. If this is left blank, the default behavior is to display the contents of the body tag."
+
+msgid "plugins.generic.inlineHtmlGalley.backToTop"
+msgstr "Back to Topp "

--- a/templates/blockDetails.tpl
+++ b/templates/blockDetails.tpl
@@ -7,10 +7,13 @@
  * Inline HTML Galley download block
  *
  *}
+{capture name='detailsBlockContent'}{call_hook name="Templates::Article::Details"}{/capture}
+{if $smarty.capture.detailsBlockContent ne ""}
 <div class="pkp_block block_inline_html_details">
 	<h2 class="title">{translate key="article.details"}</h2>
 	<div class="content">
-                {call_hook name="Templates::Article::Details"}
+		{$smarty.capture.detailsBlockContent}
 	</div>
 </div>
+{/if}
 

--- a/templates/blockDetails.tpl
+++ b/templates/blockDetails.tpl
@@ -1,0 +1,16 @@
+{**
+ * plugins/generic/inlineHtmlGalley/blockDetails.tpl
+ *
+ * Copyright (c) University of Pittsburgh
+ * Distributed under the GNU GPL v2 or later. For full terms see the file docs/COPYING.
+ *
+ * Inline HTML Galley download block
+ *
+ *}
+<div class="pkp_block block_inline_html_details">
+	<h2 class="title">{translate key="article.details"}</h2>
+	<div class="content">
+                {call_hook name="Templates::Article::Details"}
+	</div>
+</div>
+

--- a/templates/displayInline.tpl
+++ b/templates/displayInline.tpl
@@ -62,7 +62,7 @@
 				{/foreach}
 			</div>
 		{/if}
-                
+
 		{* Article abstract *}
 		{if $article->getLocalizedAbstract()}
 			<div class="article-summary" id="summary">
@@ -70,7 +70,7 @@
 					{$article->getLocalizedAbstract()|strip_unsafe_html|nl2br}
 				</div>
 			</div>
-                        {call_hook name="Templates::Article::Main"}
+			{call_hook name="Templates::Article::Main"}
 		{/if}
 	</div>
 

--- a/templates/displayInline.tpl
+++ b/templates/displayInline.tpl
@@ -62,7 +62,7 @@
 				{/foreach}
 			</div>
 		{/if}
-
+                
 		{* Article abstract *}
 		{if $article->getLocalizedAbstract()}
 			<div class="article-summary" id="summary">
@@ -70,6 +70,7 @@
 					{$article->getLocalizedAbstract()|strip_unsafe_html|nl2br}
 				</div>
 			</div>
+                        {call_hook name="Templates::Article::Main"}
 		{/if}
 	</div>
 


### PR DESCRIPTION
Adds a Details block to display content intended to be shown in the Article Details section of a non-inlineHtmlGalley site